### PR TITLE
Concise status

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,12 @@ async function report(checks = {}, timeout = 10000, decorator = { body: xml, mim
       }, decorator.name),
     };
   } catch (e) {
-    const statusCode = (e.response ? e.response.statusCode : '') || 500;
+    const istimeout = () => e.cause
+        && (e.cause.code === 'ESOCKETTIMEDOUT'
+         || e.cause.code === 'ETIMEDOUT');
+
+    const statusCode = istimeout() ? 504 // gateway timeout
+      : 502; // gateway error
     const body = (e.response ? e.response.body : '') || e.message;
     return {
       statusCode,

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ async function report(checks = {}, timeout = 10000, decorator = { body: xml, mim
         response_time: Math.abs(Date.now() - start),
         error: {
           url: e.options.uri,
-          statuscode: statusCode,
+          statuscode: e.response ? e.response.statusCode : undefined,
           body,
         },
         process: {


### PR DESCRIPTION
Timeouts are now reported with HTTP status 504 (gateway timeout) and all other errors are reported as HTTP status 502 (gateway error). The original status code will still be propagated in the error object.

Fixes #38 
