### PR TITLE
refactor(monitoring): remove config loading from package.json

### DIFF
--- a/src/newrelic.js
+++ b/src/newrelic.js
@@ -23,12 +23,7 @@ let packageJSON = {};
 // load config
 try {
   packageJSON = JSON.parse(fs.readFileSync('package.json'));
-  if (packageJSON.newrelic) {
-    config.packageName = packageJSON.newrelic.name || packageJSON.name || undefined;
-    config.groupPolicy = packageJSON.newrelic.group_policy;
-  } else {
-    config.packageName = packageJSON.name;
-  }
+  config.packageName = packageJSON.name;
 } catch (e) {
   config.packageName = undefined;
 }
@@ -59,7 +54,6 @@ function baseargs(y) {
     .option('group_policy', {
       type: 'string',
       describe: 'The name of a common policy to add the monitor to',
-      default: config.groupPolicy,
       required: false,
     });
 }

--- a/src/statuspage.js
+++ b/src/statuspage.js
@@ -19,24 +19,15 @@ const request = require('request-promise-native');
 const status = 'operational';
 
 let logger = console;
+const config = {};
 let packageJSON = {};
-let defaultName;
-let defaultDescription;
-let defaultGroup;
 
 try {
   packageJSON = JSON.parse(fs.readFileSync('package.json'));
-  if (packageJSON.statuspage) {
-    defaultName = packageJSON.statuspage.name || packageJSON.name || undefined;
-    defaultDescription = packageJSON.statuspage.description || packageJSON.description || undefined;
-    defaultGroup = packageJSON.statuspage.group || undefined;
-  } else {
-    defaultName = packageJSON.name;
-    defaultDescription = packageJSON.description;
-    defaultGroup = undefined;
-  }
+  config.name = packageJSON.name;
+  config.description = packageJSON.description;
 } catch (e) {
-  defaultName = undefined;
+  config.name = undefined;
 }
 
 function setLogger(silent) {
@@ -183,19 +174,19 @@ function baseargs(y) {
     .option('name', {
       type: 'string',
       describe: 'The name of the component',
-      required: defaultName === undefined,
-      default: defaultName,
+      required: config.name === undefined,
+      default: config.name,
     })
     .option('description', {
       type: 'string',
       describe: 'The description of the component',
-      default: defaultDescription,
+      default: config.description,
+      required: false,
     })
     .option('group', {
       type: 'string',
       describe: 'The name of an existing component group',
       required: false,
-      default: defaultGroup,
     })
     .option('silent', {
       type: 'boolean',


### PR DESCRIPTION
Fix #93. See https://github.com/adobe/helix-home/issues/72 for details.

BREAKING CHANGE: Monitoring config in package.json no longer supported. Use command parameters in .circleci/config.yml instead. See https://circleci.com/orbs/registry/orb/adobe/helix-post-deploy for
more information.