### PR TITLE
ci(circleci): use CircleCI contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
 
   semantic-release:
     executor: node10
+    context: Project Helix
 
     steps:
     - setup
@@ -78,6 +79,7 @@ jobs:
 
   branch-deploy:
     executor: node10
+    context: Project Helix
 
     steps:
     - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ executors:
         NPM_CONFIG_PREFIX: "~/.npm-global"
     working_directory: ~/repo
 
-
 orbs:
   helix-post-deploy: adobe/helix-post-deploy@1.2.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,6 @@ jobs:
 
   branch-deploy:
     executor: node10
-    context: Project Helix
 
     steps:
     - setup
@@ -99,12 +98,14 @@ workflows:
     jobs:
     - build
     - branch-deploy:
+        context: Project Helix
         requires:
           - build
         filters:
           branches:
             ignore: master
     - semantic-release:
+        context: Project Helix
         requires:
         - build
         filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,3 +111,4 @@ workflows:
         filters:
           branches:
             only: master
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ executors:
         NPM_CONFIG_PREFIX: "~/.npm-global"
     working_directory: ~/repo
 
+
 orbs:
   helix-post-deploy: adobe/helix-post-deploy@1.2.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ jobs:
 
   semantic-release:
     executor: node10
-    context: Project Helix
 
     steps:
     - setup


### PR DESCRIPTION
CircleCI Contexts (https://circleci.com/docs/2.0/contexts/) is a new feature that eases the sharing of environment variables between projects. I have created a new "Project Helix" context and I'm trying to use it in `helix-status`. If that works, we can apply the change to all our repo templates.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
