### PR TITLE
Dynamic Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub license](https://img.shields.io/github/license/adobe/helix-status.svg)](https://github.com/adobe/helix-status/blob/master/LICENSE.txt)
 [![GitHub issues](https://img.shields.io/github/issues/adobe/helix-status.svg)](https://github.com/adobe/helix-status/issues)
 [![LGTM Code Quality Grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/adobe/helix-status.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/adobe/helix-status)
-[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![Greenkeeper badge](https://badges.greenkeeper.io/adobe/helix-status.svg)](https://greenkeeper.io/)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 ## Problem
 
@@ -144,6 +144,60 @@ $http.get('https://adobeioruntime.net/api/v1/web/helix/helix-services/status@v3/
   }
 );
 ```
+
+# Advanced Checks
+
+By default, `helix-status` will take a map of URLs and make a `GET` request for each URL provided. In some scenarios, you need to provide additional detail to craft the request and `helix-status` supports three types of advanced checks for that:
+
+## Request Options
+
+If you need to adjust things like request method (from `GET` to `POST`) or set request headers (e.g. `Accept`), instead of providing a URL as string, you can provide a [request options object, according to the `request/request` documentation](https://github.com/request/request#requestoptions-callback).
+
+Make sure not to forget the `uri`.
+
+```javascript
+module.exports.main = wrap(main, 
+  { example: {
+    uri: 'http://www.example.com',
+    method: 'POST',
+    headers: {
+      accept: 'application/json'
+    }
+  }});
+```
+
+## Custom Status Check Function
+
+For more advanced use cases, you can provide a `function` in your checks. This function will be executed with the `params` of your OpenWhisk function when requested with the status check or health check URLs.
+
+Keep in mind that the check function should execute reasonably fast, but it can be async.
+
+```javascript
+module.exports.main = wrap(main, 
+  { example: function(params) => params.foo === params.bar });
+```
+
+## Request Options with Dynamic Values
+
+A combination of the two techniques above is the usage of request options with Dynamic Values. This can be used if you need to populate properties of the request object or request headers with values provided in the `params` of the execution.
+
+A typical example would be making a call to an API that requires an API key, where the API key would be stored in the default parameters of the OpenWhisk action.
+
+To achieve this, provide a request options object as described in [Request Options](#request-options), but note that values both of the `options` and the `options.headers` object can be `function`s. Each property that is a function will be replaced with the value that function returns when called with the action's parameters.
+
+```javascript
+module.exports.main = wrap(main, 
+  { example: {
+    uri: 'http://www.example.com',
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      authorization: params => `Bearer ${params.EXAMPLE_API_TOKEN}`
+    }
+  }});
+```
+
+The example above shows how to extract the `EXAMPLE_API_TOKEN` value from the action's (default) parameters and applies it to the `Authorization` header.
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,15 @@ module.exports.main = wrap(main,
 
 The example above shows how to extract the `EXAMPLE_API_TOKEN` value from the action's (default) parameters and applies it to the `Authorization` header.
 
+# Status Codes
+
+The health check reports following HTTP status codes:
+
+- `200` (OK): all health checks performed successfully
+- `504` (Gateway Timeout): the health check took too long to execute
+- `502` (Gateway Error): the health check got an error response from the checked URL
+- `500` (Server Error): the generic check function did not execute successfully
+
 # Development
 
 ## Deploying Helix Status

--- a/package-lock.json
+++ b/package-lock.json
@@ -9069,9 +9069,9 @@
       "dev": true
     },
     "npm": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.13.4.tgz",
-      "integrity": "sha512-vTcUL4SCg3AzwInWTbqg1OIaOXlzKSS8Mb8kc5avwrJpcvevDA5J9BhYSuei+fNs3pwOp4lzA5x2FVDXACvoXA==",
+      "version": "6.13.6",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.13.6.tgz",
+      "integrity": "sha512-NomC08kv7HIl1FOyLOe9Hp89kYsOsvx52huVIJ7i8hFW8Xp65lDwe/8wTIrh9q9SaQhA8hTrfXPh3BEL3TmMpw==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.5",
@@ -9159,7 +9159,7 @@
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^9.5.11",
+        "pacote": "^9.5.12",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
@@ -11441,7 +11441,7 @@
           }
         },
         "pacote": {
-          "version": "9.5.11",
+          "version": "9.5.12",
           "bundled": true,
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Report status for OpenWhisk Microservices for Uptime checks with Pingdom or New Relic",
   "main": "src/index.js",
   "scripts": {
-    "test": "nyc --reporter=text --reporter=lcov --check-coverage --branches 100 --statements 100 --lines 100 mocha",
-    "test-ci": "nyc --reporter=text --reporter=lcov --check-coverage --branches 100 --statements 100 --lines 100 mocha --reporter xunit --reporter-options output=./junit/test-results.xml && codecov",
+    "test": "nyc --reporter=text --reporter=lcov --check-coverage --branches 95 --statements 100 --lines 100 mocha",
+    "test-ci": "nyc --reporter=text --reporter=lcov --check-coverage --branches 95 --statements 100 --lines 100 mocha --reporter xunit --reporter-options output=./junit/test-results.xml && codecov",
     "lint": "./node_modules/.bin/eslint .",
     "semantic-release": "semantic-release",
     "semantic-prepare": "node ./build/prepare.js",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Report status for OpenWhisk Microservices for Uptime checks with Pingdom or New Relic",
   "main": "src/index.js",
   "scripts": {
-    "test": "nyc --reporter=text --reporter=lcov --check-coverage --branches 95 --statements 100 --lines 100 mocha",
-    "test-ci": "nyc --reporter=text --reporter=lcov --check-coverage --branches 95 --statements 100 --lines 100 mocha --reporter xunit --reporter-options output=./junit/test-results.xml && codecov",
+    "test": "nyc --reporter=text --reporter=lcov --check-coverage --branches 100 --statements 100 --lines 100 mocha",
+    "test-ci": "nyc --reporter=text --reporter=lcov --check-coverage --branches 100 --statements 100 --lines 100 mocha --reporter xunit --reporter-options output=./junit/test-results.xml && codecov",
     "lint": "./node_modules/.bin/eslint .",
     "semantic-release": "semantic-release",
     "semantic-prepare": "node ./build/prepare.js",

--- a/src/index.js
+++ b/src/index.js
@@ -184,7 +184,7 @@ async function report(checks = {}, params, timeout = 10000, decorator = { body: 
       : 502; // gateway error
     const body = (e.response ? e.response.body : '') || e.message;
     return {
-      statusCode,
+      statusCode: e.options ? statusCode : 500,
       headers: {
         'Content-Type': decorator.mime,
         'X-Version': version,
@@ -194,7 +194,7 @@ async function report(checks = {}, params, timeout = 10000, decorator = { body: 
         version,
         response_time: Math.abs(Date.now() - start),
         error: {
-          url: e.options.uri,
+          url: e.options ? e.options.uri : undefined,
           statuscode: e.response ? e.response.statusCode : undefined,
           body,
         },

--- a/src/index.js
+++ b/src/index.js
@@ -60,33 +60,98 @@ const getVersion = memoize(async () => (await getPackage()).version || 'n/a');
 
 const getName = memoize(async () => (await getPackage()).name || 'n/a');
 
-
-async function report(checks = {}, timeout = 10000, decorator = { body: xml, mime: 'application/xml', name: 'pingdom_http_custom_check' }) {
-  const start = Date.now();
+async function uricheck(key, uri, timeout) {
   const version = await getVersion();
   const name = await getName();
 
-  try {
-    const checker = async ([key, uri]) => {
-      const response = await request({
-        uri,
-        resolveWithFullResponse: true,
-        time: true,
-        timeout,
-        headers: {
-          'user-agent': `helix-status/${pkgversion} (${name}@${version})`,
-        },
-      });
-      return {
-        key,
-        response,
-      };
-    };
+  const response = await request({
+    uri,
+    resolveWithFullResponse: true,
+    time: true,
+    timeout,
+    headers: {
+      'user-agent': `helix-status/${pkgversion} (${name}@${version})`,
+    },
+  });
+  return {
+    key,
+    response,
+  };
+}
 
+function seal(obj = {}, init, params) {
+  return Object.keys(obj).reduce((p, key) => {
+    const value = obj[key];
+    if (typeof value === 'function') {
+      // eslint-disable-next-line no-param-reassign
+      p[key] = value(params);
+    } else {
+      // eslint-disable-next-line no-param-reassign
+      p[key] = value;
+    }
+    return p;
+  }, init);
+}
+
+async function requestcheck(key, opts, timeout, params) {
+  const version = await getVersion();
+  const name = await getName();
+
+  const requestoptions = seal(opts, {
+    resolveWithFullResponse: true,
+    time: true,
+    timeout,
+  }, params);
+
+  const headers = seal(opts.headers, {
+    'user-agent': `helix-status/${pkgversion} (${name}@${version})`,
+  }, params);
+  requestoptions.headers = headers;
+
+  const response = await request(requestoptions);
+  return {
+    key,
+    response,
+  };
+}
+
+async function funccheck(key, func, params) {
+  const start = Date.now();
+  const result = await func(params);
+  const end = Date.now();
+
+  return {
+    key,
+    response: {
+      result,
+      timings: {
+        end: end - start,
+      },
+    },
+  };
+}
+
+function makechecker(timeout, params) {
+  return async function checker([key, check]) {
+    if (typeof check === 'string') {
+      return uricheck(key, check, timeout);
+    } else if (typeof check === 'function') {
+      return funccheck(key, check, params);
+    }
+    return requestcheck(key, check, timeout, params);
+  };
+}
+
+
+async function report(checks = {}, params, timeout = 10000, decorator = { body: xml, mime: 'application/xml', name: 'pingdom_http_custom_check' }) {
+  const start = Date.now();
+  const version = await getVersion();
+
+  try {
     const runchecks = Object.keys(checks)
       .filter((key) => key.match('^[a-z0-9]+$'))
       .map((key) => [key, checks[key]])
-      .map(checker);
+      .map(makechecker(timeout, params));
 
     const checkresults = await Promise.all(runchecks);
 
@@ -146,12 +211,12 @@ function wrap(func, checks) {
     // Pingdom status check?
     if (params
       && params.__ow_path === PINGDOM_XML_PATH) {
-      return report(checks);
+      return report(checks, params);
     }
     // New Relic status check?
     if (params
       && params.__ow_path === HEALTHCHECK_PATH) {
-      return report(checks, 10000, {
+      return report(checks, params, 10000, {
         body: (j) => j,
         mime: 'application/json',
       });
@@ -176,14 +241,14 @@ function probotStatus(checks = {}) {
     const router = probot.route(`/${baseroute}`);
 
     router.get(`/${pingroute}`, async (_, res) => {
-      const r = await report(checks);
+      const r = await report(checks, {});
 
       res.set(r.headers);
       res.send(r.body);
     });
 
     router.get(`/${healthroute}`, async (_, res) => {
-      const r = await report(checks, 10000, {
+      const r = await report(checks, {}, 10000, {
         body: (j) => j,
         mime: 'application/json',
       });
@@ -209,7 +274,7 @@ function main(paramsorfunction, checks = {}) {
     // New Relic status check?
     if (paramsorfunction
       && paramsorfunction.__ow_path === HEALTHCHECK_PATH) {
-      return report(paramsorfunction, 10000, {
+      return report(paramsorfunction, {}, 10000, {
         body: (j) => j,
         mime: 'application/json',
       });

--- a/test/fixtures/recordings/Index-Tests_647266286/index-function-returns-n_4071433248/a-for-missing-package-json_270967369/recording.har
+++ b/test/fixtures/recordings/Index-Tests_647266286/index-function-returns-n_4071433248/a-for-missing-package-json_270967369/recording.har
@@ -1,0 +1,113 @@
+{
+  "log": {
+    "_recordingName": "Index Tests/index function returns n/a for missing package.json",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "3.0.0"
+    },
+    "entries": [
+      {
+        "_id": "e723b47417a3fd5de8048d50464bc9e0",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "user-agent",
+              "value": "helix-status/7.0.3 (n/a@n/a)"
+            },
+            {
+              "name": "host",
+              "value": "www.example.com"
+            }
+          ],
+          "headersSize": 106,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://www.example.com/"
+        },
+        "response": {
+          "bodySize": 1256,
+          "content": {
+            "mimeType": "text/html; charset=UTF-8",
+            "size": 1256,
+            "text": "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n    <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html; charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color: #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system, system-ui, BlinkMacSystemFont, \"Segoe UI\", \"Open Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width: 600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color: #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n        text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n    <p>This domain is for use in illustrative examples in documents. You may use this\n    domain in literature without prior coordination or asking for permission.</p>\n    <p><a href=\"https://www.iana.org/domains/example\">More information...</a></p>\n</div>\n</body>\n</html>\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "age",
+              "value": "443808"
+            },
+            {
+              "name": "cache-control",
+              "value": "max-age=604800"
+            },
+            {
+              "name": "content-type",
+              "value": "text/html; charset=UTF-8"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 15:04:11 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "\"3147526947+ident\""
+            },
+            {
+              "name": "expires",
+              "value": "Tue, 28 Jan 2020 15:04:11 GMT"
+            },
+            {
+              "name": "last-modified",
+              "value": "Thu, 17 Oct 2019 07:18:26 GMT"
+            },
+            {
+              "name": "server",
+              "value": "ECS (nyb/1D2F)"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "x-cache",
+              "value": "HIT"
+            },
+            {
+              "name": "content-length",
+              "value": "1256"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 337,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T15:04:11.057Z",
+        "time": 503,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 503
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/fixtures/recordings/Index-Tests_647266286/wrap-function-supports-request-options-check-with-functions_4061816471/recording.har
+++ b/test/fixtures/recordings/Index-Tests_647266286/wrap-function-supports-request-options-check-with-functions_4061816471/recording.har
@@ -1,0 +1,113 @@
+{
+  "log": {
+    "_recordingName": "Index Tests/wrap function supports request options check with functions",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "3.0.0"
+    },
+    "entries": [
+      {
+        "_id": "85774d82bc8002d5f957891794ffa5bd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "user-agent",
+              "value": "helix-status/7.0.3 (@adobe/helix-status@7.0.3)"
+            },
+            {
+              "name": "referer",
+              "value": "/_status_check/healthcheck.json"
+            },
+            {
+              "name": "host",
+              "value": "www.example.com"
+            },
+            {
+              "name": "content-length",
+              "value": 0
+            }
+          ],
+          "headersSize": 186,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [],
+          "url": "https://www.example.com/"
+        },
+        "response": {
+          "bodySize": 1256,
+          "content": {
+            "mimeType": "text/html; charset=UTF-8",
+            "size": 1256,
+            "text": "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n    <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html; charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color: #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system, system-ui, BlinkMacSystemFont, \"Segoe UI\", \"Open Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width: 600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color: #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n        text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n    <p>This domain is for use in illustrative examples in documents. You may use this\n    domain in literature without prior coordination or asking for permission.</p>\n    <p><a href=\"https://www.iana.org/domains/example\">More information...</a></p>\n</div>\n</body>\n</html>\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "cache-control",
+              "value": "max-age=604800"
+            },
+            {
+              "name": "content-type",
+              "value": "text/html; charset=UTF-8"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Jan 2020 09:19:49 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "\"3147526947\""
+            },
+            {
+              "name": "expires",
+              "value": "Thu, 23 Jan 2020 09:19:49 GMT"
+            },
+            {
+              "name": "last-modified",
+              "value": "Thu, 17 Oct 2019 07:18:26 GMT"
+            },
+            {
+              "name": "server",
+              "value": "EOS (vny/0450)"
+            },
+            {
+              "name": "content-length",
+              "value": "1256"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 303,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-16T09:19:48.686Z",
+        "time": 566,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 566
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/fixtures/recordings/Index-Tests_647266286/wrap-function-supports-request-options-check_3738071926/recording.har
+++ b/test/fixtures/recordings/Index-Tests_647266286/wrap-function-supports-request-options-check_3738071926/recording.har
@@ -1,0 +1,109 @@
+{
+  "log": {
+    "_recordingName": "Index Tests/wrap function supports request options check",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "3.0.0"
+    },
+    "entries": [
+      {
+        "_id": "f5898a5d0d94f177a8354428e4cbcd98",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "user-agent",
+              "value": "helix-status/7.0.3 (@adobe/helix-status@7.0.3)"
+            },
+            {
+              "name": "host",
+              "value": "www.example.com"
+            },
+            {
+              "name": "content-length",
+              "value": 0
+            }
+          ],
+          "headersSize": 144,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "queryString": [],
+          "url": "https://www.example.com/"
+        },
+        "response": {
+          "bodySize": 1256,
+          "content": {
+            "mimeType": "text/html; charset=UTF-8",
+            "size": 1256,
+            "text": "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n    <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html; charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color: #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: -apple-system, system-ui, BlinkMacSystemFont, \"Segoe UI\", \"Open Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width: 600px;\n        margin: 5em auto;\n        padding: 2em;\n        background-color: #fdfdff;\n        border-radius: 0.5em;\n        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);\n    }\n    a:link, a:visited {\n        color: #38488f;\n        text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        div {\n            margin: 0 auto;\n            width: auto;\n        }\n    }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n    <p>This domain is for use in illustrative examples in documents. You may use this\n    domain in literature without prior coordination or asking for permission.</p>\n    <p><a href=\"https://www.iana.org/domains/example\">More information...</a></p>\n</div>\n</body>\n</html>\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "cache-control",
+              "value": "max-age=604800"
+            },
+            {
+              "name": "content-type",
+              "value": "text/html; charset=UTF-8"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 16 Jan 2020 08:34:52 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "\"3147526947\""
+            },
+            {
+              "name": "expires",
+              "value": "Thu, 23 Jan 2020 08:34:52 GMT"
+            },
+            {
+              "name": "last-modified",
+              "value": "Thu, 17 Oct 2019 07:18:26 GMT"
+            },
+            {
+              "name": "server",
+              "value": "EOS (vny/0453)"
+            },
+            {
+              "name": "content-length",
+              "value": "1256"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 303,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-16T08:34:51.695Z",
+        "time": 586,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 586
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -195,7 +195,9 @@ describe('Index Tests', () => {
     const pwd = process.cwd();
     try {
       process.chdir(path.resolve(__dirname, 'fixtures', 'no_package'));
-      const result = await main({});
+      const result = await main({
+        example: 'https://www.example.com',
+      });
       assert.equal(result.statusCode, 200);
       assert.ok(result.body.match(/<version>n\/a<\/version>/));
     } finally {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -85,6 +85,81 @@ describe('Index Tests', () => {
     assert.equal(result2, 'boo');
   });
 
+  it('wrap function supports function check', async () => {
+    let triggered = false;
+    const wrapped = wrap(({ name } = {}) => name || 'foo', {
+      funccheck: () => {
+        triggered = true;
+      },
+    });
+
+    assert.deepEqual(typeof wrapped, 'function');
+    assert.deepEqual(wrapped(), 'foo', 'calling without health check path passes through');
+    assert.ok(!triggered);
+
+    const result = await wrapped({ __ow_path: `${HEALTHCHECK_PATH}` });
+    assert.equal(result.statusCode, 200, 'calling with health check path get reports');
+    assert.equal(result.headers['Content-Type'], 'application/json');
+    assert.equal(typeof result.body, 'object');
+    assert.ok(triggered);
+  });
+
+  it('wrap function supports function check with options', async () => {
+    let triggered = false;
+    const wrapped = wrap(({ name } = {}) => name || 'foo', {
+      funccheck: (opts) => {
+        triggered = opts;
+      },
+    });
+
+    assert.deepEqual(typeof wrapped, 'function');
+    assert.deepEqual(wrapped(), 'foo', 'calling without health check path passes through');
+    assert.ok(!triggered);
+
+    const result = await wrapped({ __ow_path: `${HEALTHCHECK_PATH}` });
+    assert.equal(result.statusCode, 200, 'calling with health check path get reports');
+    assert.equal(result.headers['Content-Type'], 'application/json');
+    assert.equal(typeof result.body, 'object');
+    assert.ok(triggered);
+  });
+
+  it('wrap function supports request options check', async () => {
+    const wrapped = wrap(({ name } = {}) => name || 'foo', {
+      optscheck: {
+        uri: 'https://www.example.com',
+        method: 'POST',
+      },
+    });
+
+    assert.deepEqual(typeof wrapped, 'function');
+    assert.deepEqual(wrapped(), 'foo', 'calling without health check path passes through');
+
+    const result = await wrapped({ __ow_path: `${HEALTHCHECK_PATH}` });
+    assert.equal(result.statusCode, 200, 'calling with health check path get reports');
+    assert.equal(result.headers['Content-Type'], 'application/json');
+    assert.equal(typeof result.body, 'object');
+  });
+
+  it('wrap function supports request options check with functions', async () => {
+    const wrapped = wrap(({ name } = {}) => name || 'foo', {
+      optscheck: {
+        uri: 'https://www.example.com',
+        method: 'POST',
+        headers: {
+          Referer: (params) => params.__ow_path,
+        },
+      },
+    });
+
+    assert.deepEqual(typeof wrapped, 'function');
+    assert.deepEqual(wrapped(), 'foo', 'calling without health check path passes through');
+
+    const result = await wrapped({ __ow_path: `${HEALTHCHECK_PATH}` });
+    assert.equal(result.statusCode, 200, 'calling with health check path get reports');
+    assert.equal(result.headers['Content-Type'], 'application/json');
+    assert.equal(typeof result.body, 'object');
+  });
+
   it('index function returns status code for objects', async () => {
     const result = await index({});
     assert.equal(result.statusCode, 200);
@@ -250,7 +325,7 @@ describe('Timeout Tests', () => {
   it('index function fails after timeout', async () => {
     const result = await report({
       snail: 'https://httpstat.us/200?sleep=1000',
-    }, 10);
+    }, {}, 10);
 
     assert.ok(result.body.match(/<status>failed/));
     assert.ok(result.body.match(/<version>\d+\./));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -104,6 +104,22 @@ describe('Index Tests', () => {
     assert.ok(triggered);
   });
 
+  it('wrap function reports failure for failing function check', async () => {
+    const wrapped = wrap(({ name } = {}) => name || 'foo', {
+      funccheck: () => {
+        throw new Error('Boom!');
+      },
+    });
+
+    assert.deepEqual(typeof wrapped, 'function');
+    assert.deepEqual(wrapped(), 'foo', 'calling without health check path passes through');
+
+    const result = await wrapped({ __ow_path: `${HEALTHCHECK_PATH}` });
+    assert.equal(result.statusCode, 500, 'calling with health check path get reports');
+    assert.equal(result.headers['Content-Type'], 'application/json');
+    assert.equal(typeof result.body, 'object');
+  });
+
   it('wrap function supports function check with options', async () => {
     let triggered = false;
     const wrapped = wrap(({ name } = {}) => name || 'foo', {


### PR DESCRIPTION
Adds three new ways of performing status checks:

- provide `request` options (to override HTTP method or set headers)
- provide a `function` (to do advanced stuff)
- provide `request` options where some fields are `function`s (to dynamically set headers)

fixes #48 and gives us the ability to provide a GitHub token to `helix-static`, so we won't run into rate limit errors anymore.