### PR TITLE
feat(status): report current version in context

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -269,6 +269,7 @@ export function helixStatus(func, checks) {
       }
       return result;
     }
+    args.context.version = version;
     return func(...args);
   };
 }


### PR DESCRIPTION
Sometimes it would be cool to be able to report the current version of the function, even if you are not running a full blown health check report. This change adds a `context.version` field to the downstream functions that has the info you need.

In a consumer, say `helix-run-query` you'd then simply read

```javascript
params.add('version', context.version);
```

without having to try to parse package.json yourself.
